### PR TITLE
Bugfix/unit needs to be refreshed when lr buttons at screen bottom used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /RandomFirstNickLastButtonMod.v12.XCOM_suo
+
+/RandomFirstNickLastButtonMod/PublishedFileId.ID

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -116,10 +116,23 @@ event OnInit(UIScreen Screen)
 {
 	CharacterGenerator	= `XCOMGAME.Spawn( class 'XGCharacterGenerator' );
 	CustomizeInfoScreen	= UICustomize_Info(Screen);
-	Unit				= GetUnit();
+	RefreshUnit();
 
 	InitUI();
 }
+
+simulated function OnReceiveFocus(UIScreen Screen)
+{
+        `log("RandomNicknameButton.OnReceiveFocus");
+
+		RefreshUnit();
+}
+
+simulated function OnLoseFocus(UIScreen Screen)
+{
+        `log("RandomNicknameButton.OnLoseFocus");
+}
+
 
 simulated function InitUI()
 {
@@ -386,6 +399,11 @@ simulated function ForceCustomizationMenuRefresh()
 simulated function XComGameState_Unit GetUnit()
 {
 	return CustomizeInfoScreen.Movie.Pres.GetCustomizationUnit();
+}
+
+simulated function RefreshUnit()
+{
+	Unit = GetUnit();
 }
 
 simulated function bool InShell()

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -123,7 +123,21 @@ event OnInit(UIScreen Screen)
 
 simulated function OnReceiveFocus(UIScreen Screen)
 {
+	/*
+		Previously, the Unit was only set in the OnInit event; the result
+		was that using the < and > buttons in the Armory proper (in-game)
+		would result in an embarrassing bug: the mod wouldn't refresh
+		the Unit upon these button presses and thus would bring that
+		soldier back in, superimposed awkwardly over the one that the
+		user was actually viewing.
+
+		The < and > buttons (bottom middle) in the armory proper (in-game)
+		cause OnReceiveFocus events to proc here, so refreshing here
+		solves the problem.
+	*/
+
         `log("RandomNicknameButton.OnReceiveFocus");
+		`log(" --> Resetting the stored Unit.");
 
 		RefreshUnit();
 }


### PR DESCRIPTION
This branch fixes the problem; one I never saw because I do most of my testing in the Character Pool and basically NEVER use the < and > buttons at bottom-middle of the screen while in the armory when playing the game. (I back out and use the menu to pick another soldier.)
