### PR TITLE
Bugfix/adding asset cleanup

### DIFF
--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -151,7 +151,7 @@ simulated function /*event*/ OnReceiveFocus(UIScreen Screen)
 		solves the problem.
 	*/
 
-        `log("RandomNicknameButton.OnReceiveFocus");
+        BigLog("RandomNicknameButton.OnReceiveFocus");
 		`log(" --> Resetting the stored Unit.");
 
 		RefreshUnit();
@@ -159,7 +159,7 @@ simulated function /*event*/ OnReceiveFocus(UIScreen Screen)
 
 simulated function /*event*/ OnLoseFocus(UIScreen Screen)
 {
-        `log("RandomNicknameButton.OnLoseFocus");
+        BigLog("RandomNicknameButton.OnLoseFocus");
 }
 
 event OnRemoved(UIScreen Screen)
@@ -168,7 +168,7 @@ event OnRemoved(UIScreen Screen)
 		Asset cleanup; this should only trigger once the player
 		leaves the Armory or Character Pool. (*Should*.)
 	*/
-	`log("RandomNicknameButton.OnRemoved() -> CLEANING UP.");
+	BigLog("RandomNicknameButton.OnRemoved() -> CLEANING UP.");
 
 	CustomizeInfoScreen.Destroy();
 	CharacterGenerator.Destroy();
@@ -471,6 +471,24 @@ simulated function bool InShell()
 
 	return XComShellPresentationLayer(CustomizeInfoScreen.Movie.Pres) != none;
 }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+	Some utility code to make my life easier.
+
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+ simulated function BigLog(string logEntry)
+ {
+	`log("* * * * * * * * * * * * * * * * * *");
+	`log("");
+	`log(logEntry);
+	`log("");
+	`log("* * * * * * * * * * * * * * * * * *");
+ }
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 defaultproperties
 {

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -125,7 +125,18 @@ event OnInit(UIScreen Screen)
 	InitUI();
 }
 
-event OnReceiveFocus(UIScreen Screen)
+/*
+	A NOTE ON EVENT VS. SIMULATED FUNCTION.
+
+	I set these two functions as 'simulated function' as an accident
+	and made a discovery. They seem to work either way, but when I
+	tag them as events, there are bouts of slowdown upon clicks on
+	my buttons.
+
+	No idea why.
+*/
+
+simulated function /*event*/ OnReceiveFocus(UIScreen Screen)
 {
 	/*
 		Previously, the Unit was only set in the OnInit event; the result
@@ -146,11 +157,38 @@ event OnReceiveFocus(UIScreen Screen)
 		RefreshUnit();
 }
 
-event OnLoseFocus(UIScreen Screen)
+simulated function /*event*/ OnLoseFocus(UIScreen Screen)
 {
         `log("RandomNicknameButton.OnLoseFocus");
 }
 
+event OnRemoved(UIScreen Screen)
+{
+	/*
+		Asset cleanup; this should only trigger once the player
+		leaves the Armory or Character Pool. (*Should*.)
+	*/
+	`log("RandomNicknameButton.OnRemoved() -> CLEANING UP.");
+
+	CustomizeInfoScreen.Destroy();
+	CharacterGenerator.Destroy();
+	
+	/*
+		Every example I've seen of XComCharacterGenerators being
+		created seems to lack any kind of explicit cleanup for the
+		character generator.
+	*/
+	//Unit.Destroy();
+
+	RandomButtonBG.Destroy();
+	RandomButtonTitle.Destroy();
+
+	RandomFirstnameButton.Destroy();
+	RandomNicknameButton.Destroy();
+	RandomLastnameButton.Destroy();
+	RandomCountryButton.Destroy();
+	RandomBioButton.Destroy();
+}
 
 simulated function InitUI()
 {

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -82,6 +82,10 @@ const BUTTON_HEIGHT				=   36;
 const BUTTON_SPACING			=	3;
 
 /*
+	SUMMARY: The weird spacing in these strings IS ON PURPOSE.
+
+	DETAILS FOLLOW.
+
 	Here's my disappointing hack to try and finally make the buttons
 	look reasonable. No matter what I do I can't get .SetWidth() or
 	.SetSize() to affect the width of the buttons at all. There aren't
@@ -121,7 +125,7 @@ event OnInit(UIScreen Screen)
 	InitUI();
 }
 
-simulated function OnReceiveFocus(UIScreen Screen)
+event OnReceiveFocus(UIScreen Screen)
 {
 	/*
 		Previously, the Unit was only set in the OnInit event; the result
@@ -142,7 +146,7 @@ simulated function OnReceiveFocus(UIScreen Screen)
 		RefreshUnit();
 }
 
-simulated function OnLoseFocus(UIScreen Screen)
+event OnLoseFocus(UIScreen Screen)
 {
         `log("RandomNicknameButton.OnLoseFocus");
 }


### PR DESCRIPTION
I did what testing I could given my environment; I don't have a profiler or any kind of exhaustive testing, but the asset cleanups are being called, nothing is crashing, and I don't see any visible growth (watching the mem footprint size in task mgr).

I didn't see growth prior to doing this either though, but cleanup is strictly better. (Right?)

Possibly I could have kept on trusting garbage collection. But, here we are.

As I said in one of the commits, I don't see any examples of explicit release of XComCharacterGenerators, even though they are explicitly Spawned like UE3 Actors. (The .destroy() method isn't a member of it either.) So I left that one dangling, but - again - I don't see evidence of a leak.
