### PR TITLE
Bugfix/fixing stance override loss

### DIFF
--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -441,9 +441,52 @@ simulated function ForceCustomizationMenuRefresh()
 		combined with the refresh call, calling PopulateData does the trick.
 	*/
 
+	// tried here
 	CustomizeInfoScreen.Header.PopulateData(Unit);
 	CustomizeInfoScreen.UpdateData();							// hopefully force update on stock button labels themselves
-	CustomizeInfoScreen.CustomizeManager.Refresh(Unit, Unit);	// bit of a hack
+
+	// Looks like all this stuff below is unnecessary. The .Refresh() call is what screws
+	// up the stance, and the call isn't required for the purpose I thought it filled.
+
+	//ResetSoldierIdleStance();									// gets its own function due to the size of its comment
+	//CustomizeInfoScreen.CustomizeManager.Refresh(Unit, Unit);	// bit of a hack	
+
+	//CustomizeInfoScreen.CustomizeManager.UpdateCamera();
+}
+
+simulated function ResetSoldierIdleStance()
+{
+	/*
+		Calls to the UpdateData functions (when I force an update to reflect data changes) result
+		in the soldier's By the Book Stance override being lost, which results in them - worst case
+		- slumping down if they're wounded in the Customize Info Screen. This bug's very minor, but
+		I finally think I know how to fix it.
+
+		CustomizeInfoScreen is UICustomize_Info, which extends UICustomize, which has member CustomizeManager.
+		CustomizeManger is XComCharacterCustomization, which has member ActorPawn, of base UE3 type Actor.
+
+		UICustomize uses this type to do this (along with their comment):
+			
+			// Play the "By The Book" idle to minimize character overlap with UI elements
+			XComHumanPawn(CustomizeManager.ActorPawn).PlayHQIdleAnim(IdleAnimName);
+
+		which *looks* like a cast. In fact, the XComHumanPawn class has member function
+		PlayHQIdleAnim(). Seems promising.
+
+		The desired value for IdleAnimName is this (thanks, grep):
+
+			X2StrategyElement_DefaultSoldierPersonalities.uc:24:    Template.IdleAnimName = 'Idle_ByTheBook_TG02';
+
+		And it looks like I can get it via the Unit:
+
+			IdleAnimName = Unit.GetPersonalityTemplate().IdleAnimName;
+	*/
+	
+	local name	IdleAnimName;
+
+	IdleAnimName = Unit.GetPersonalityTemplate().IdleAnimName;
+	XComHumanPawn(CustomizeInfoScreen.CustomizeManager.ActorPawn).PlayHQIdleAnim(IdleAnimName);
+	
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -7,8 +7,9 @@
 
 	BUGS.
 
-	* (FIXED? TESTING) After my forced refresh, the character's forced "by the book" pose is lost, which is most
+	* (FIXED) After my forced refresh, the character's forced "by the book" pose is lost, which is most
 		apparent when the character is wounded (they'll slump suddenly).
+		* I was making an unnecessary call that was causing the problem. I was young.
 		
 	* (FIXED*) The label on the Random Bio button isn't left justified as all the other buttons are; no idea
 		why. :\
@@ -358,6 +359,11 @@ simulated function OnRandomLastnameButtonPress(UIButton button)
 	CharacterGenerator.GenerateName(Unit.kAppearance.iGender, Unit.GetCountry(), strNewFirstname, strNewLastname, Unit.kAppearance.iRace);
 	
 	Unit.SetUnitName(strFirstname, strNewLastname, strNickname);
+
+	/*
+		Currently, last names aren't reflected in bios but no reason they couldn't be
+		one day.
+	*/
 	UpdateCharacterBio(strLastname, strNewLastname);
 	ForceCustomizationMenuRefresh();
 }
@@ -441,53 +447,10 @@ simulated function ForceCustomizationMenuRefresh()
 		combined with the refresh call, calling PopulateData does the trick.
 	*/
 
-	// tried here
 	CustomizeInfoScreen.Header.PopulateData(Unit);
-	CustomizeInfoScreen.UpdateData();							// hopefully force update on stock button labels themselves
-
-	// Looks like all this stuff below is unnecessary. The .Refresh() call is what screws
-	// up the stance, and the call isn't required for the purpose I thought it filled.
-
-	//ResetSoldierIdleStance();									// gets its own function due to the size of its comment
-	//CustomizeInfoScreen.CustomizeManager.Refresh(Unit, Unit);	// bit of a hack	
-
-	//CustomizeInfoScreen.CustomizeManager.UpdateCamera();
+	CustomizeInfoScreen.UpdateData();				// gets the country button label
 }
 
-simulated function ResetSoldierIdleStance()
-{
-	/*
-		Calls to the UpdateData functions (when I force an update to reflect data changes) result
-		in the soldier's By the Book Stance override being lost, which results in them - worst case
-		- slumping down if they're wounded in the Customize Info Screen. This bug's very minor, but
-		I finally think I know how to fix it.
-
-		CustomizeInfoScreen is UICustomize_Info, which extends UICustomize, which has member CustomizeManager.
-		CustomizeManger is XComCharacterCustomization, which has member ActorPawn, of base UE3 type Actor.
-
-		UICustomize uses this type to do this (along with their comment):
-			
-			// Play the "By The Book" idle to minimize character overlap with UI elements
-			XComHumanPawn(CustomizeManager.ActorPawn).PlayHQIdleAnim(IdleAnimName);
-
-		which *looks* like a cast. In fact, the XComHumanPawn class has member function
-		PlayHQIdleAnim(). Seems promising.
-
-		The desired value for IdleAnimName is this (thanks, grep):
-
-			X2StrategyElement_DefaultSoldierPersonalities.uc:24:    Template.IdleAnimName = 'Idle_ByTheBook_TG02';
-
-		And it looks like I can get it via the Unit:
-
-			IdleAnimName = Unit.GetPersonalityTemplate().IdleAnimName;
-	*/
-	
-	local name	IdleAnimName;
-
-	IdleAnimName = Unit.GetPersonalityTemplate().IdleAnimName;
-	XComHumanPawn(CustomizeInfoScreen.CustomizeManager.ActorPawn).PlayHQIdleAnim(IdleAnimName);
-	
-}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 


### PR DESCRIPTION
This patch fixes the bug that resulted in soldiers who were wounded losing their stance override and slumping down (incorrectly) on the Customize Info Screen after one of my buttons was pressed.

I was calling this function in the erroneous belief that it would update the button label data:
`CustomizeInfoScreen.CustomizeManager.Refresh(Unit, Unit);`
and calling that function created this issue.

I don't need that function as the UpdateData function updates the button labels; and without it, things still work and we don't lose the stance override. Woohoo!
