### PR TITLE
Bugfix/invalid country causes crash upon randomcountry button press

### DIFF
--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -374,23 +374,38 @@ simulated function OnRandomCountryButtonPress(UIButton Button)
 	local name						newCountry;
 	local string					strNewCountry;
 
+	local bool						bValidCountry;
+
 	/*
 		XGCharacterGenerator has member PickOriginCountry() which returns a UE3 Name, the single quote kind.
-
 		Country looks to be stored in kSoldier (TSoldier) private member of XGCharacterGenerator.
-
 		XComGameState_Unit has members SetCountry and GetCountry.
-
 		Easy peasy.
+
+		NOTE. Sometimes mods that add countries aren't removed cleanly, which
+		seems to cause crash for users when they hit this button.
 	*/
 
-	strOldCountry = Unit.GetCountryTemplate().DisplayName;
+	if (Unit.GetCountryTemplate() != none)
+	{
+		strOldCountry = Unit.GetCountryTemplate().DisplayName;
+
+		if (Len(strOldCountry) < 1)
+			bValidCountry = false;
+		else
+			bValidCountry = true;
+
+	} else {
+		bValidCountry = false;
+	}
 
 	newCountry = CharacterGenerator.PickOriginCountry();
 	Unit.SetCountry(newCountry);
 	strNewCountry = Unit.GetCountryTemplate().DisplayName;
 
-	UpdateCharacterBio(strOldCountry, strNewCountry);
+	if (bValidCountry)
+		UpdateCharacterBio(strOldCountry, strNewCountry);
+
 	ForceCustomizationMenuRefresh();
 }
 

--- a/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
+++ b/RandomFirstNickLastButtonMod/Src/RandomFirstNickLastNameButtonMod/Classes/RandomNicknameButton.uc
@@ -384,6 +384,14 @@ simulated function OnRandomCountryButtonPress(UIButton Button)
 
 		NOTE. Sometimes mods that add countries aren't removed cleanly, which
 		seems to cause crash for users when they hit this button.
+
+		Two things could be the case:
+			the country template is coming back none
+		OR	the country name is empty (or weird).
+
+		I can't check it for corruption, but hopefully that's not the issue.
+
+		(If it is, I can't do anything about this.)
 	*/
 
 	if (Unit.GetCountryTemplate() != none)


### PR DESCRIPTION
This _should_ fix the issue. I'd never actually clicked the Random Country button on any of my own soldiers when they've been affected by the "no flag" bug (which happens when I turn off mods that add flags) but it makes total sense that XCOM would run into trouble with it. Anyway, hopefully this will fix things.
